### PR TITLE
chore: drop lodash.assign

### DIFF
--- a/.changeset/kind-cloths-scream.md
+++ b/.changeset/kind-cloths-scream.md
@@ -1,0 +1,5 @@
+---
+"@articulate/asyncios": patch
+---
+
+drop lodash.assign as a dep

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,11 +1,6 @@
 {
-  "plugins": [
-    "es5"
-  ],
-  "extends": [
-    "standard",
-    "plugin:es5/no-es2015"
-  ],
+  "plugins": [],
+  "extends": ["standard"],
   "env": {
     "browser": true,
     "commonjs": true,

--- a/index.js
+++ b/index.js
@@ -1,11 +1,10 @@
 var Async = require('crocks/Async')
-var assign = require('lodash.assign')
 var axios = require('axios')
 
 function asyncios (params) {
   var cancelTokenSource = axios.CancelToken.source()
 
-  var opts = assign(
+  var opts = Object.assign(
     { cancelToken: cancelTokenSource.token },
     params
   )

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "test:watch": "karma start"
   },
   "dependencies": {
-    "crocks": "^0.12.3",
-    "lodash.assign": "^4.2.0"
+    "crocks": "^0.12.3"
   },
   "peerDependencies": {
     "axios": ">=0.16.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3142,11 +3142,6 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-lodash.assign@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
-  integrity sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=
-
 lodash.memoize@~3.0.3:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-3.0.4.tgz#2dcbd2c287cbc0a55cc42328bd0c736150d53e3f"


### PR DESCRIPTION
## Description

This drops `lodash.assign` because we're 10 years past ES2015, and it's one less dependency in the chain. If this were a more recent feature and/or had actual other dependents on this package, I'd call this a breaking change (requiring a higher ES version), but I don't think that's truly worth it.